### PR TITLE
Improved encoding guessing for source files

### DIFF
--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -319,11 +319,11 @@ source({M, P, Name, Path}, Dir, Suffix, Env, Set, Private, Hidden,
 
 guess_encoding(File) ->
     try epp:read_encoding(File) of
-        none -> latin1;
+        none -> epp:default_encoding();
         Enc  -> Enc
     catch
         _:_ ->
-            latin1
+            epp:default_encoding()
     end.
 
 write_file(Text, Dir, F) ->


### PR DESCRIPTION
Since epp:default_encoding() is used as the default encoding for the README.md file generated from overview.edoc, it would be good with consistent behaviour when determining default encoding for source files.
