### PR TITLE
fix: wrap ShortDesc in <p> for clean linebreaks

### DIFF
--- a/src/edown_layout.erl
+++ b/src/edown_layout.erl
@@ -186,7 +186,7 @@ layout_module(#xmlElement{name = module, content = Es}=E, Opts) ->
             ++ [{h1, Title}]
 	    ++ doc_index(FullDesc, Functions, Types)
 	    ++ [{p,[]}]
-	    ++ ShortDesc
+	    ++ [{p, ShortDesc}]
 	    ++ [{p,[]}]
 	    ++ copyright(Es)
 	    ++ deprecated(Es, "module")


### PR DESCRIPTION
If copyright is missing, the description field
is not separated from the next field, for example
a behaviour entry. Wrapping in `<p>` ensures that
any following sections will appear on their own
line in resulting html.