### PR TITLE
Remove edoc_refs:relative_package_path/1 usage

### DIFF
--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -377,7 +377,7 @@ modules_frame(Ms) ->
          || M <- Ms])}].
 
 module_ref(M) ->
-    edoc_refs:relative_package_path(M, '') ++ ?DEFAULT_FILE_SUFFIX.
+    atom_to_list(M) ++ ?DEFAULT_FILE_SUFFIX.
 
 
 %% NEW-OPTIONS: overview


### PR DESCRIPTION
edoc_refs:relative_package_path was removed in Erlang 18:
https://github.com/erlang/otp/commit/6f492b98505ee6d68b9f438915dfbd3616a1b729#diff-0aac9d2e50a09cb7c696945ebdf597dbL184