### PR TITLE
Prepare for OTP 24 EDoc

### DIFF
--- a/src/edoc_compat.hrl
+++ b/src/edoc_compat.hrl
@@ -1,0 +1,13 @@
+-ifndef(__EDOC_COMPAT_HRL__).
+-define(__EDOC_COMPAT_HRL__, true).
+
+-ifndef(NO_APP).
+%% OTP 24+ EDoc
+-define(NO_APP, no_app).
+-define(context, doclet_context).
+-else.
+%% Pre OTP 24 EDoc
+-define(context, context).
+-endif. %% NO_APP
+
+-endif. %% __EDOC_COMPAT_HRL__

--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -29,6 +29,7 @@
 -import(edoc_report, [report/2, warning/2]).
 
 -include_lib("edoc/include/edoc_doclet.hrl").
+-include("edoc_compat.hrl").
 
 -define(EDOC_APP, edoc).
 -define(DEFAULT_FILE_SUFFIX, ".md").
@@ -109,9 +110,9 @@ run(#doclet_toc{}=Cmd, Ctxt) ->
     toc(Cmd#doclet_toc.paths, Ctxt).
 
 gen(Sources, App, Modules, Ctxt) ->
-    Dir = Ctxt#doclet_context.dir,
-    Env = Ctxt#doclet_context.env,
-    Options0 = Ctxt#doclet_context.opts,
+    Dir = Ctxt#?context.dir,
+    Env = Ctxt#?context.env,
+    Options0 = Ctxt#?context.opts,
     Options = set_app_default([{layout,edown_layout} |
 			       Options0] ++
 				  [{file_suffix,".md"}]),
@@ -249,7 +250,7 @@ get_git_branch() ->
 
 title(App, Options) ->
     proplists:get_value(title, Options,
-			if App == no_app ->
+			if App == ?NO_APP ->
 				"Overview";
 			   true ->
 				io_lib:fwrite("Application: ~s", [App])

--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -109,9 +109,9 @@ run(#doclet_toc{}=Cmd, Ctxt) ->
     toc(Cmd#doclet_toc.paths, Ctxt).
 
 gen(Sources, App, Modules, Ctxt) ->
-    Dir = Ctxt#context.dir,
-    Env = Ctxt#context.env,
-    Options0 = Ctxt#context.opts,
+    Dir = Ctxt#doclet_context.dir,
+    Env = Ctxt#doclet_context.env,
+    Options0 = Ctxt#doclet_context.opts,
     Options = set_app_default([{layout,edown_layout} |
 			       Options0] ++
 				  [{file_suffix,".md"}]),
@@ -249,7 +249,7 @@ get_git_branch() ->
 
 title(App, Options) ->
     proplists:get_value(title, Options,
-			if App == ?NO_APP ->
+			if App == no_app ->
 				"Overview";
 			   true ->
 				io_lib:fwrite("Application: ~s", [App])


### PR DESCRIPTION
https://github.com/erlang/otp/pull/2914 removes the `NO_APP` macro and changes the `#context{}` record name. This change prepares EDown for OTP 24 and makes sure it will still work with older OTP versions.