### PR TITLE
Generate `https` links to the Erlang documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,14 @@ See [bin/MARKEDOC-README.md](http://github.com/uwiger/edown/blob/master/bin/MARK
 
 **Linux**`$ sed -r -f markedoc.sed <markdown file> > <edoc file>`
 
+
+## Modules ##
+
+
+<table width="100%" border="0" summary="list of modules">
+<tr><td><a href="http://github.com/uwiger/edown/blob/master/doc/edown_doclet.md" class="module">edown_doclet</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/edown/blob/master/doc/edown_layout.md" class="module">edown_layout</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/edown/blob/master/doc/edown_lib.md" class="module">edown_lib</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/edown/blob/master/doc/edown_make.md" class="module">edown_make</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/edown/blob/master/doc/edown_xmerl.md" class="module">edown_xmerl</a></td></tr></table>
+

--- a/doc/README.md
+++ b/doc/README.md
@@ -166,3 +166,14 @@ See [bin/MARKEDOC-README.md](bin/MARKEDOC-README.md).
 
 **Linux**`$ sed -r -f markedoc.sed <markdown file> > <edoc file>`
 
+
+## Modules ##
+
+
+<table width="100%" border="0" summary="list of modules">
+<tr><td><a href="edown_doclet.md" class="module">edown_doclet</a></td></tr>
+<tr><td><a href="edown_layout.md" class="module">edown_layout</a></td></tr>
+<tr><td><a href="edown_lib.md" class="module">edown_lib</a></td></tr>
+<tr><td><a href="edown_make.md" class="module">edown_make</a></td></tr>
+<tr><td><a href="edown_xmerl.md" class="module">edown_xmerl</a></td></tr></table>
+

--- a/doc/edown_doclet.md
+++ b/doc/edown_doclet.md
@@ -34,8 +34,8 @@ run(Command::<a href="#type-doclet_gen">doclet_gen()</a> | <a href="#type-doclet
 
 Main doclet entry point.
 
-Also see [`//edoc/edoc:layout/2`](http://www.erlang.org/doc/man/edoc.html#layout-2) for layout-related options, and
-[`//edoc/edoc:get_doc/2`](http://www.erlang.org/doc/man/edoc.html#get_doc-2) for options related to reading source
+Also see [`//edoc/edoc:layout/2`](https://www.erlang.org/doc/man/edoc.html#layout-2) for layout-related options, and
+[`//edoc/edoc:get_doc/2`](https://www.erlang.org/doc/man/edoc.html#get_doc-2) for options related to reading source
 files.
 
 Options:
@@ -68,7 +68,7 @@ functions will also be included. The default value is <code>false</code>.
 
 
 
-<dt><code>{overview, <a href="http://www.erlang.org/doc/man/edoc.html#type-filename">//edoc/edoc:filename()</a>}</code>
+<dt><code>{overview, <a href="https://www.erlang.org/doc/man/edoc.html#type-filename">//edoc/edoc:filename()</a>}</code>
 </dt>
 
 
@@ -108,7 +108,7 @@ specified, no stylesheet reference will be generated.
 
 
 
-<dt><code>{stylesheet_file, <a href="http://www.erlang.org/doc/man/edoc.html#type-filename">//edoc/edoc:filename()</a>}</code>
+<dt><code>{stylesheet_file, <a href="https://www.erlang.org/doc/man/edoc.html#type-filename">//edoc/edoc:filename()</a>}</code>
 </dt>
 
 

--- a/doc/edown_layout.md
+++ b/doc/edown_layout.md
@@ -107,14 +107,14 @@ the source file. The default value is <code>true</code>.
 
 
 
-<dd>Specifies an <a href="http://www.erlang.org/doc/man/index.html" target="_top"><code>xmerl</code></a> callback module to be
-used for exporting the documentation. See <a href="http://www.erlang.org/doc/man/xmerl.html#export_simple_content-2"><code>//xmerl/xmerl:export_simple_content/2</code></a> for details.
+<dd>Specifies an <a docgen-rel="seeapp" docgen-href="xmerl:index" href="https://www.erlang.org/doc/man/index.html" target="_top"><code>xmerl</code></a> callback module to be
+used for exporting the documentation. See <a docgen-rel="seemfa" docgen-href="xmerl:xmerl#export_simple_content/2" href="https://www.erlang.org/doc/man/xmerl.html#export_simple_content-2"><code>//xmerl/xmerl:export_simple_content/2</code></a> for details.
 </dd>
 
 
 
 
-__See also:__ [//edoc/edoc:layout/2](http://www.erlang.org/doc/man/edoc.html#layout-2), [edown_doclet:layout/2](edown_doclet.md#layout-2).
+__See also:__ [//edoc/edoc:layout/2](https://www.erlang.org/doc/man/edoc.html#layout-2), [edown_doclet:layout/2](edown_doclet.md#layout-2).
 
 <a name="overview-2"></a>
 

--- a/doc/edown_make.md
+++ b/doc/edown_make.md
@@ -9,7 +9,7 @@
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#from_script-1">from_script/1</a></td><td>Reads ConfigFile and calls <a href="edoc.md#application-3"><code>edoc:application/3</code></a></td></tr><tr><td valign="top"><a href="#main-1">main/1</a></td><td>Escript entry point for building edown (or edoc) documentation.</td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#from_script-1">from_script/1</a></td><td>Reads ConfigFile and calls <a docgen-rel="seemfa" docgen-href="edoc#application/3" href="edoc.md#application-3"><code>edoc:application/3</code></a></td></tr><tr><td valign="top"><a href="#main-1">main/1</a></td><td>Escript entry point for building edown (or edoc) documentation.</td></tr></table>
 
 
 <a name="functions"></a>

--- a/make_doc
+++ b/make_doc
@@ -7,7 +7,7 @@
 %% to do this with 'rebar doc'.
 %%
 main([]) ->
-    code:add_patha("ebin"),
+    code:add_patha("_build/default/lib/edown/ebin"), % from rebar3
     Default = "uwiger",
     U = case os:getenv("TGT") of
 	    [] -> Default;
@@ -19,12 +19,12 @@ main([]) ->
     R = edoc:application(edown, ".",
 			 [{doclet, edown_doclet},
 			  {source_path, ["src"]},
-			  {app_default,"http://www.erlang.org/doc/man"},
+			  {app_default,"https://www.erlang.org/doc/man"},
 			  {stylesheet, ""},  % don't copy stylesheet.css
 			  {image, ""},       % don't copy erlang.png
                           {edown_target, target()},
 			  {top_level_readme,
-			   {"./README.md", TopURL}}]),
+			   {"./README.md", TopURL, "master"}}]),
     case R of
 	ok ->
 	    halt();

--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -142,7 +142,7 @@ right_suffix(File, Options) ->
 set_app_default(Opts) ->
     case lists:keyfind(app_default,1,Opts) of
 	false ->
-	    [{app_default, "http://www.erlang.org/doc/man"}|Opts];
+	    [{app_default, "https://www.erlang.org/doc/man"}|Opts];
 	_ ->
 	    Opts
     end.

--- a/src/edown_lib.erl
+++ b/src/edown_lib.erl
@@ -41,8 +41,16 @@ redirect_uri(#xmlElement{} = E) ->
 redirect_uri(_E) ->
     false.
 
-redirect_uri("http://www.erlang.org" ++ _ = URI, _, E) ->
+redirect_uri("https://www.erlang.org" ++ _ = URI, _, E) ->
     %% abusing the filename API a little - but whatever works...
+    case filename:split(URI) of
+	[_,"www.erlang.org","doc","man",_,"doc",Mod] ->
+	    NewURI = "https://www.erlang.org/doc/man/" ++ Mod,
+	    replace_uri(NewURI, E);
+	_Split ->
+	    false
+    end;
+redirect_uri("http://www.erlang.org" ++ _ = URI, _, E) ->
     case filename:split(URI) of
 	[_,"www.erlang.org","doc","man",_,"doc",Mod] ->
 	    NewURI = "http://www.erlang.org/doc/man/" ++ Mod,
@@ -55,7 +63,7 @@ redirect_uri("/" ++ _  = URI, "//" ++ _, E) ->
 	true ->
 	    case lists:reverse(filename:split(URI)) of
 		[Mod, "doc", _App | _] ->
-		    NewURI = "http://www.erlang.org/doc/man/" ++ Mod,
+		    NewURI = "https://www.erlang.org/doc/man/" ++ Mod,
 		    replace_uri(NewURI, E);
 		_ ->
 		    false


### PR DESCRIPTION
This PR enables a project to use the configuration:

 `{app_default,"https://www.erlang.org/doc/man"}`

to get generated links to the Erlang documentation that uses https for secure transport.
Providing https links instead of http is preferred by some projects.