### PR TITLE
Fix crash of edown with functions having several returns tags

### DIFF
--- a/src/edown_layout.erl
+++ b/src/edown_layout.erl
@@ -1029,6 +1029,11 @@ get_content(Name, Es) ->
     case get_elem(Name, Es) of
 	[#xmlElement{content = Es1}] ->
 	    Es1;
+	% Workaround a bug in edoc where several returns tags are generated
+	% when there are several specification clauses
+	% See: https://github.com/erlang/otp/issues/7576
+	[#xmlElement{content = Es1}, #xmlElement{} | _] when Name =:= returns ->
+	    Es1;
 	[] -> []
     end.
 


### PR DESCRIPTION
This PR sits on top of #25 
In addition to the proposed change, there is an issue if a function has a specification with several clauses and a returns tag. In this case, because of a bug in edoc, several returns tags are generated which crashes edown.

See https://github.com/erlang/otp/issues/7576